### PR TITLE
refactor: improve evaluation logic with multiplicative scoring and decomposed checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Checks like Redundancy, Conflicts, and Effectiveness are skipped for sparse conf
 
 ## Scoring
 
-Each dimension receives a score from 0 to 100. The overall score is a weighted average:
+Each dimension receives a score from 0 to 100, computed using multiplicative penalties (each finding reduces the score by a percentage rather than a fixed amount, so scores degrade gracefully instead of hitting zero). The overall score is a weighted average:
 
 | Dimension | Weight |
 |-----------|--------|

--- a/src/config_doctor.py
+++ b/src/config_doctor.py
@@ -1537,10 +1537,6 @@ def run_diagnosis(
                 check.name(), check.display_name(), [], 1.0, False
             ))
 
-    # Free content strings after checks are done (no longer needed)
-    for fm in iter_content_files(files):
-        fm.content = ""
-
     overall_score, overall_rating = calculate_overall(results)
     return results, files, ctx, overall_score, overall_rating
 
@@ -1563,6 +1559,10 @@ def main(argv: Optional[List[str]] = None) -> None:
     else:
         print(format_report(results, files, ctx, overall_score,
                             overall_rating, args.context_window))
+
+    # Free content strings in CLI path (not needed after output)
+    for fm in iter_content_files(files):
+        fm.content = ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #5

## Changes

- Switch `_make_result()` to multiplicative scoring (`score *= 1-penalty`) so scores degrade gracefully instead of saturating at 0.0 (e.g., 4 errors → 0.24 instead of 0.0)
- Relax `RedundancyCheck` normalization: whitespace-normalize + lowercase only (was stripping all punctuation/spaces), minimum directive length 5→10 characters
- Decompose `BudgetCheck.run()` into 3 private methods: `_check_total_budget()`, `_check_per_file_budget()`, `_check_memory_lines()`
- Clear `fm.content` after all checks complete to free memory
- Update README to document multiplicative scoring behavior
- Add tests: multiplicative scoring (5), redundancy false-positive prevention (1) → 104 total

## Tests

```
104 passed in 0.06s
```